### PR TITLE
Acm 1932  add status urls to config

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -12,14 +12,14 @@ sites:
     url: $STATUS_URL
     method: POST
     body: '{"username": "$GH_USERNAME", "password": "$GH_SECRET", "statusType": "fetchers"}'
-    __dangerous__body_down: "more than 30% of fetchers are down"
-    __dangerous__body_degraded: "between 0-30% of fetchers are down"
+    __dangerous__body_down: "more than 30% are down"
+    __dangerous__body_degraded: "between 0-30% are down"
   - name: Processors
     url: $STATUS_URL
     method: POST
     body: '{"username": "$GH_USERNAME", "password": "$GH_SECRET", "statusType": "processors"}'
-    __dangerous__body_down: "more than 30% of data processors are down"
-    __dangerous__body_degraded: "between 0-30% of data processors are down"
+    __dangerous__body_down: "more than 30% are down"
+    __dangerous__body_degraded: "between 0-30% are down"
 
 status-website:
   # Add your custom domain below, or remove the next line if you don't have a domain

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -8,6 +8,14 @@ sites:
     url: https://www.acumen.io
   - name: Acumen API
     url: $BACKEND_URL
+  - name: Fetchers
+    url: $STATUS_URL
+    method: POST
+    body: '{"username": "gh-status-page", "password": "$GH_SECRET", "statusType": "fetchers"}'
+  - name: Processors
+    url: $STATUS_URL
+    method: POST
+    body: '{"username": "gh-status-page", "password": "$GH_SECRET", "statusType": "processors"}'
 
 status-website:
   # Add your custom domain below, or remove the next line if you don't have a domain

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -11,11 +11,15 @@ sites:
   - name: Fetchers
     url: $STATUS_URL
     method: POST
-    body: '{"username": "gh-status-page", "password": "$GH_SECRET", "statusType": "fetchers"}'
+    body: '{"username": "$GH_USERNAME", "password": "$GH_SECRET", "statusType": "fetchers"}'
+    __dangerous__body_down: "more than 30% of fetchers are down"
+    __dangerous__body_degraded: "between 0-30% of fetchers are down"
   - name: Processors
     url: $STATUS_URL
     method: POST
-    body: '{"username": "gh-status-page", "password": "$GH_SECRET", "statusType": "processors"}'
+    body: '{"username": "$GH_USERNAME", "password": "$GH_SECRET", "statusType": "processors"}'
+    __dangerous__body_down: "more than 30% of data processors are down"
+    __dangerous__body_degraded: "between 0-30% of data processors are down"
 
 status-website:
   # Add your custom domain below, or remove the next line if you don't have a domain

--- a/history/acumen-api.yml
+++ b/history/acumen-api.yml
@@ -1,7 +1,7 @@
 url: $BACKEND_URL  
 status: up
 code: 200
-responseTime: 158
-lastUpdated: 2020-12-09T08:41:54.409Z
+responseTime: 97
+lastUpdated: 2020-12-09T12:53:21.488Z
 startTime: Sun Dec 06 2020 13:45:13 GMT+0000 (Coordinated Universal Time)
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/acumen-api.yml
+++ b/history/acumen-api.yml
@@ -1,7 +1,7 @@
 url: $BACKEND_URL  
 status: up
 code: 200
-responseTime: 97
-lastUpdated: 2020-12-09T12:53:21.488Z
+responseTime: 181
+lastUpdated: 2020-12-14T07:48:48.375Z
 startTime: Sun Dec 06 2020 13:45:13 GMT+0000 (Coordinated Universal Time)
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/acumen-website.yml
+++ b/history/acumen-website.yml
@@ -1,7 +1,7 @@
 url: https://www.acumen.io  
 status: up
 code: 200
-responseTime: 130
-lastUpdated: 2020-12-09T12:53:21.110Z
+responseTime: 385
+lastUpdated: 2020-12-14T07:48:47.918Z
 startTime: Sun Dec 06 2020 13:45:12 GMT+0000 (Coordinated Universal Time)
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/acumen-website.yml
+++ b/history/acumen-website.yml
@@ -1,7 +1,7 @@
 url: https://www.acumen.io  
 status: up
 code: 200
-responseTime: 161
-lastUpdated: 2020-12-09T08:41:53.963Z
+responseTime: 130
+lastUpdated: 2020-12-09T12:53:21.110Z
 startTime: Sun Dec 06 2020 13:45:12 GMT+0000 (Coordinated Universal Time)
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/fetchers.yml
+++ b/history/fetchers.yml
@@ -1,0 +1,7 @@
+url: $STATUS_URL  
+status: down
+code: 0
+responseTime: 0
+lastUpdated: 2020-12-09T12:53:21.795Z
+startTime: Wed Dec 09 2020 12:53:21 GMT+0000 (Coordinated Universal Time)
+generator: Upptime <https://github.com/upptime/upptime>

--- a/history/fetchers.yml
+++ b/history/fetchers.yml
@@ -1,7 +1,7 @@
 url: $STATUS_URL  
 status: down
-code: 0
-responseTime: 0
-lastUpdated: 2020-12-09T12:53:21.795Z
+code: 404
+responseTime: 41
+lastUpdated: 2020-12-14T07:48:48.727Z
 startTime: Wed Dec 09 2020 12:53:21 GMT+0000 (Coordinated Universal Time)
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/processors.yml
+++ b/history/processors.yml
@@ -1,0 +1,7 @@
+url: $STATUS_URL  
+status: down
+code: 0
+responseTime: 0
+lastUpdated: 2020-12-09T12:53:22.271Z
+startTime: Wed Dec 09 2020 12:53:22 GMT+0000 (Coordinated Universal Time)
+generator: Upptime <https://github.com/upptime/upptime>

--- a/history/processors.yml
+++ b/history/processors.yml
@@ -1,7 +1,7 @@
 url: $STATUS_URL  
 status: down
-code: 0
-responseTime: 0
-lastUpdated: 2020-12-09T12:53:22.271Z
+code: 404
+responseTime: 41
+lastUpdated: 2020-12-14T07:48:49.090Z
 startTime: Wed Dec 09 2020 12:53:22 GMT+0000 (Coordinated Universal Time)
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
changed the configuration file to support the fetcher & processor endpoints. They won't work though until we set a production environment variable for the status page password to the endpoint and set it in the github secrets